### PR TITLE
Get rid of move_to_end

### DIFF
--- a/adafruit_ble_broadcastnet.py
+++ b/adafruit_ble_broadcastnet.py
@@ -149,10 +149,11 @@ class AdafruitSensorMeasurement(Advertisement):
     """Battery voltage in millivolts. Saves two bytes over voltage and is more readable in bare
        packets."""
 
-    def __init__(self, *, sequence_number=None):
-        super().__init__()
-        if sequence_number:
-            self.sequence_number = sequence_number
+    def __init__(self, *, entry=None, sequence_number=None):
+        super().__init__(entry=entry)
+        if entry:
+            return
+        self.sequence_number = 0
 
     def __str__(self):
         parts = []
@@ -163,13 +164,6 @@ class AdafruitSensorMeasurement(Advertisement):
                 if value is not None:
                     parts.append("{}={}".format(attr, str(value)))
         return "<{} {} >".format(self.__class__.__name__, " ".join(parts))
-
-    def __bytes__(self):
-        """The raw packet bytes."""
-        # Must reorder the ManufacturerData contents so the sequence number field is always first.
-        # Necessary to ensure that match_prefixes works right to reconstruct on the receiver.
-        self.data_dict[255].data.move_to_end(3, last=False)
-        return super().__bytes__()
 
     def split(self, max_packet_size=31):
         """Split the measurement into multiple measurements with the given max_packet_size. Yields

--- a/adafruit_ble_broadcastnet.py
+++ b/adafruit_ble_broadcastnet.py
@@ -149,11 +149,11 @@ class AdafruitSensorMeasurement(Advertisement):
     """Battery voltage in millivolts. Saves two bytes over voltage and is more readable in bare
        packets."""
 
-    def __init__(self, *, entry=None, sequence_number=None):
+    def __init__(self, *, entry=None, sequence_number=0):
         super().__init__(entry=entry)
         if entry:
             return
-        self.sequence_number = 0
+        self.sequence_number = sequence_number
 
     def __str__(self):
         parts = []

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # Author details
     author="Adafruit Industries",
     author_email="circuitpython@adafruit.com",
-    install_requires=["Adafruit-Blinka", "adafruit-circuitpython-ble"],
+    install_requires=["Adafruit-Blinka", "adafruit-circuitpython-ble >= 8.0.0"],
     # Choose your license
     license="MIT",
     # See https://pypi.python.org/pypi?%3Aaction=list_classifiers


### PR DESCRIPTION
Instead, just set a placeholder sequence_number

I need to verify that this preserves the sequence number when reading.

Fixes #18