### PR TITLE
Fix Build CI issue

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,7 +5,6 @@
 .. use this format as the module name: "adafruit_foo.foo"
 
 .. automodule:: adafruit_ble_broadcastnet
-
    :members:
 
    .. autoclass:: AdafruitSensorMeasurement

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -5,4 +5,8 @@
 .. use this format as the module name: "adafruit_foo.foo"
 
 .. automodule:: adafruit_ble_broadcastnet
+
    :members:
+
+   .. autoclass:: AdafruitSensorMeasurement
+      :exclude-members: match_prefixes

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,4 +9,5 @@
    :members:
 
    .. autoclass:: AdafruitSensorMeasurement
+      :members:
       :exclude-members: match_prefixes

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,7 @@
 
 .. automodule:: adafruit_ble_broadcastnet
    :members:
+   :exclude-members: AdafruitSensorMeasurement
 
    .. autoclass:: AdafruitSensorMeasurement
       :members:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-adafruit-circuitpython-ble
+adafruit-circuitpython-ble>=8.0.0


### PR DESCRIPTION
Looks like Sphinx will try to document undocumented members if they're inherited from somewhere where they are documented.  This isn't necessarily a problem, but it seems to not pair well with any local target references in that documentation.

They're might be another way to fix the issue, possibly doing so in `adafruit_ble.advertising.Advertisement.match_prefixes`, but this just prevents it from trying to be documented at all, which seemed find in this case.