### PR TITLE
Revert changes in favor of hyperspecifying targets in adafruit_ble

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,8 +6,3 @@
 
 .. automodule:: adafruit_ble_broadcastnet
    :members:
-   :exclude-members: AdafruitSensorMeasurement
-
-   .. autoclass:: AdafruitSensorMeasurement
-      :members:
-      :exclude-members: match_prefixes


### PR DESCRIPTION
Depends on https://github.com/adafruit/Adafruit_CircuitPython_BLE/pull/167

Reverts changes made in previous merge in favor of just hyperspecifying the targets in `adafruit_ble`